### PR TITLE
Fix loading of dependent modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,13 +2,12 @@
  * Module dependencies.
  */
 var Strategy = require('./bypass_strategy');
-var JwtStrategy = require('./bypass_jwt_strategy');
+var JwtStrategy = require('./device_token_strategy');
 
 /**
  * Expose `Strategy` directly from package.
  */
 exports = module.exports = Strategy;
-exports = module.exports = JwtStrategy;
 
 /**
  * Export constructors.

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -1,0 +1,16 @@
+var index = require("../lib/index");
+var bypassStrategy = require('../lib/bypass_strategy');
+var deviceTokenStrategy = require("../lib/device_token_strategy");
+var auth = require("../lib/bypass_auth");
+
+describe("index", function() {
+  it("exports constructors for dependent modules", function() {
+    expect(index.Strategy).toEqual(bypassStrategy);
+    expect(index.JwtStrategy).toEqual(deviceTokenStrategy);
+    expect(index.Auth).toEqual(auth);
+  });
+
+  it("exports Strategy directly from the package", function() {
+    expect(index).toEqual(bypassStrategy);
+  });
+});


### PR DESCRIPTION
Apps that require this module cannot load due to
```
Error: Cannot find module './bypass_jwt_strategy'
```

Note: I'm assuming we still want Strategy to be exported directly out of the index module.  We had set it, and then were immediately overriding it with JwtStrategy.